### PR TITLE
Add composer and application key setup to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,17 @@ The backend uses the [Laravel](https://laravel.com/) PHP framework.
 4. Run the following commands in order:
 
 ```bash
+# Install composer dependencies
+composer install
+
 # Create a database (credentials must be set in `.env` first)
 php artisan db:create
 
 # Run migrations and seed test data into the database
 php artisan migrate --seed
+
+# Create application key
+php artisan key:generate
 
 # Create an user with administrator privileges
 # (you will be prompted for username/email/password)


### PR DESCRIPTION
I was trying to set this up and stumbled over the (obvious) composer install and the application key generation.

There is still an issue with yarn complaining about a missing "_config.yml" and Laravel missing the manifest for Laravel mix.