### PR TITLE
Added laravel/sail development environment integration

### DIFF
--- a/.env.sail
+++ b/.env.sail
@@ -1,7 +1,8 @@
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_PORT=8080
+APP_URL=http://localhost:8080
 
 LOG_CHANNEL=stack
 

--- a/.env.sail
+++ b/.env.sail
@@ -1,0 +1,42 @@
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+
+DB_CONNECTION=mysql
+DB_HOST=mariadb
+DB_PORT=3306
+DB_DATABASE=godotassetlibrary
+DB_USERNAME=sail
+DB_PASSWORD=password
+
+BROADCAST_DRIVER=log
+CACHE_DRIVER=file
+QUEUE_CONNECTION=sync
+SESSION_DRIVER=file
+SESSION_LIFETIME=120
+
+REDIS_HOST=redis
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+MAIL_DRIVER=smtp
+MAIL_HOST=smtp.mailtrap.io
+MAIL_PORT=2525
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_ENCRYPTION=null
+MAIL_FROM_ADDRESS=hello@example.com
+
+# Create an OAuth app on GitHub then fill the client ID and secret below:
+# https://github.com/settings/applications/new
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+
+# Create an OAuth app on GitLab with the `read_user` scope only then fill
+# the client ID and secret below:
+# https://gitlab.com/profile/applications
+GITLAB_CLIENT_ID=
+GITLAB_CLIENT_SECRET=

--- a/README.md
+++ b/README.md
@@ -40,16 +40,16 @@ It also asks whether it should
   as the `DB_*`/`REDIS_*` settings are important for operating inside the sail environment.
 
 ```bash
-# start the development environment
+# Start the development environment
 ./sail up -d
 
-# continue with setting up the backend
+# Continue with setting up the backend...
 ./sail artisan db:create
 ./sail artisan migrate --seed
 ./sail artisan key:generate
 ./sail artisan admin:create
 
-# and the frontend
+# ...and the frontend
 ./sail yarn
 ./sail yarn development
 ```
@@ -57,7 +57,7 @@ It also asks whether it should
 The development environment will be available at http://localhost:8080 by default.
 
 ```bash
-# stop the development environment
+# Stop the development environment
 ./sail stop
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ Internet Explorer isn't supported.
 
 ### Development environment
 
-This project uses [Laravel Sail](https://laravel.com/docs/8.x/sail) to supply you with a docker
+This project uses [Laravel Sail](https://laravel.com/docs/sail) to supply you with a docker
 based development environment. Please take a moment to familiarize yourself with its concepts.
 
 We also supply a small convenience shell script named `sail` in the project root which forwards all
 commands to the `vendor/bin/sail` command.
 
-It also
-- asks if it should [install the composer dependencies using a container](https://laravel.com/docs/8.x/sail#installing-composer-dependencies-for-existing-projects),
-  when not finding the sail command
-- asks if it should install `.env.sail` as the current `.env` if none is currently present  
-  **NOTE:** if you already have an `.env` installed, consider replacing it with `.env.sail`
-  as the `DB_*`/`REDIS_*` settings are important for operating inside the sail environment
+It also asks whether it should
+- [install the composer dependencies using a container](https://laravel.com/docs/sail#installing-composer-dependencies-for-existing-projects),
+  if not finding the sail command.
+- install `.env.sail` as the current `.env`, if none is currently present.  
+  **NOTE:** If you already have an `.env` installed, consider replacing it with `.env.sail`
+  as the `DB_*`/`REDIS_*` settings are important for operating inside the sail environment.
 
 ```bash
 # start the development environment

--- a/README.md
+++ b/README.md
@@ -24,6 +24,39 @@ When working on new features, keep in mind this website only supports
 
 Internet Explorer isn't supported.
 
+### Development environment
+
+This project uses [Laravel Sail](https://laravel.com/docs/8.x/sail) to supply you with a docker
+based development environment. Please take a moment to familiarize yourself with its concepts.
+
+We also supply a small convenience shell script named `sail` in the project root which forwards all
+commands to the `vendor/bin/sail` command.
+
+It also
+- asks if it should [install the composer dependencies using a container](https://laravel.com/docs/8.x/sail#installing-composer-dependencies-for-existing-projects),
+  when not finding the sail command
+- asks if it should install `.env.sail` as the current `.env` if none is currently present  
+  **NOTE:** if you already have an `.env` installed, consider replacing it with `.env.sail`
+  as the `DB_*`/`REDIS_*` settings are important for operating inside the sail environment
+
+```bash
+# start the development environment
+./sail up -d
+
+# continue with setting up the backend
+./sail artisan db:create
+./sail artisan migrate --seed
+./sail artisan key:generate
+./sail artisan admin:create
+
+# and the frontend
+./sail yarn
+./sail yarn development
+
+# stop the development environment
+./sail stop
+```
+
 ### Production environment
 
 The production environment uses **PHP 7.3**. To preserve compatibility with the

--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ It also asks whether it should
 # and the frontend
 ./sail yarn
 ./sail yarn development
+```
 
+The development environment will be available at http://localhost:8080 by default.
+
+```bash
 # stop the development environment
 ./sail stop
 ```

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Internet Explorer isn't supported.
 
 ### Development environment
 
-This project uses [Laravel Sail](https://laravel.com/docs/sail) to supply you with a docker
-based development environment. Please take a moment to familiarize yourself with its concepts.
+This project uses [Laravel Sail](https://laravel.com/docs/sail) to supply you with a Docker-based
+development environment. Please take a moment to familiarize yourself with its concepts.
 
 We also supply a small convenience shell script named `sail` in the project root which forwards all
 commands to the `vendor/bin/sail` command.

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "barryvdh/laravel-debugbar": "^3.5.1",
         "fzaninotto/faker": "^1.9.1",
+        "laravel/sail": "^1.15",
         "matt-allan/laravel-code-style": "^0.6.0",
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28265fe5bb66416226b6e09953295a08",
+    "content-hash": "20e5a647e26169ce9e79dd6b4efd70d3",
     "packages": [
         {
             "name": "brick/math",
@@ -7417,6 +7417,66 @@
                 "source": "https://github.com/justinrainbow/json-schema/tree/5.2.10"
             },
             "time": "2020-05-27T16:41:55+00:00"
+        },
+        {
+            "name": "laravel/sail",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/sail.git",
+                "reference": "676e1ff33c1b8af657779f62f57360c376cba666"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/676e1ff33c1b8af657779f62f57360c376cba666",
+                "reference": "676e1ff33c1b8af657779f62f57360c376cba666",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^8.0|^9.0",
+                "illuminate/contracts": "^8.0|^9.0",
+                "illuminate/support": "^8.0|^9.0",
+                "php": "^7.3|^8.0"
+            },
+            "bin": [
+                "bin/sail"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Sail\\SailServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Sail\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Docker files for running a basic Laravel application.",
+            "keywords": [
+                "docker",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/sail/issues",
+                "source": "https://github.com/laravel/sail"
+            },
+            "time": "2022-06-24T13:56:11+00:00"
         },
         {
             "name": "matt-allan/laravel-code-style",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+# For more information: https://laravel.com/docs/sail
+version: '3'
+services:
+    laravel.test:
+        build:
+            context: ./vendor/laravel/sail/runtimes/7.4
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-7.4/app
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
+        ports:
+            - '${APP_PORT:-80}:80'
+            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - mariadb
+    mariadb:
+        image: 'mariadb:10'
+        ports:
+            - '${FORWARD_DB_PORT:-3306}:3306'
+        environment:
+            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: "%"
+            MYSQL_DATABASE: '${DB_DATABASE}'
+            MYSQL_USER: '${DB_USERNAME}'
+            MYSQL_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+        volumes:
+            - 'sail-mariadb:/var/lib/mysql'
+            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+        networks:
+            - sail
+        healthcheck:
+            test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
+            retries: 3
+            timeout: 5s
+networks:
+    sail:
+        driver: bridge
+volumes:
+    sail-mariadb:
+        driver: local

--- a/sail
+++ b/sail
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+BASE_DIR="$(cd "$(dirname "$0")"; pwd)";
+SAIL_EXECUTABLE="vendor/bin/sail";
+SAIL_ENV_FILE=".env.sail"
+
+if [ ! -f "$BASE_DIR/$SAIL_EXECUTABLE" ]; then
+    printf "$SAIL_EXECUTABLE was not found. I would now spin up a container to install PHP dependencies. Okay (y/n)? "
+    read ANSWER
+
+    if [ "$ANSWER" != "${ANSWER#[Yy]}" ] ;then
+        docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            -v $BASE_DIR:/var/www/html \
+            -w /var/www/html \
+            laravelsail/php74-composer:latest \
+            composer install --ignore-platform-reqs
+    fi
+fi
+
+if [ ! -f "$BASE_DIR/.env" ]; then
+    printf "No .env file found. I would install .env.sail. Okay (y/n)? "
+    read ANSWER
+
+    if [ "$ANSWER" != "${ANSWER#[Yy]}" ] ;then
+        cp "$BASE_DIR/$SAIL_ENV_FILE" "$BASE_DIR/.env"
+    fi
+fi
+
+"$BASE_DIR/$SAIL_EXECUTABLE" $@


### PR DESCRIPTION
### What was done

I integrated a development environment, after seeing the previous effort was abandoned/stale.
I opted for `laravel/sail` because it is the officially supported docker based development setup.
This would close #58 and would supersede #104.

For a better overview I would now cite the addition to the `README.md`:

### Development environment

This project uses [Laravel Sail](https://laravel.com/docs/sail) to supply you with a docker based development environment.
Please take a moment to familiarize yourself with its concepts.

We also supply a small convenience shell script named `sail` in the project root which forwards all commands to the `vendor/bin/sail` command.

It also asks whether it should
- [install the composer dependencies using a container](https://laravel.com/docs/sail#installing-composer-dependencies-for-existing-projects), if not finding the sail command.
- install `.env.sail` as the current `.env`, if none is currently present.  
  **NOTE:** If you already have an `.env` installed, consider replacing it with `.env.sail` as the `DB_*`/`REDIS_*` settings are important for operating inside the sail environment.

```bash
# start the development environment
./sail up -d

# continue with setting up the backend
./sail artisan db:create
./sail artisan migrate --seed
./sail artisan key:generate
./sail artisan admin:create

# and the frontend
./sail yarn
./sail yarn development

# stop the development environment
./sail stop
```