### PR TITLE
Center magnifying glass on search bar, increase tooltip opacity

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -27,7 +27,7 @@
   --active-overlay: hsla(0, 0%, 0%, 0.13);
 
   /* <https://github.com/kazzkiq/balloon.css#customizing-tooltips> */
-  --balloon-color: hsla(0, 0%, 0%, 0.75);
+  --balloon-color: hsla(0, 0%, 0%, 0.95);
   --balloon-font-size: 0.85rem;
   --body-background-color: #eff1f5;
   --body-color: hsl(0, 0%, 20%);
@@ -38,7 +38,7 @@
   :root {
     --hover-overlay: hsla(0, 0%, 100%, 0.065);
     --active-overlay: hsla(0, 0%, 100%, 0.13);
-    --balloon-color: hsla(0, 0%, 30%, 0.75);
+    --balloon-color: hsla(0, 0%, 30%, 0.95);
     --body-background-color: theme('colors.gray.900');
     --body-color: theme('colors.gray.300');
     --border-color: theme('colors.gray.700');

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -65,7 +65,7 @@ license = MIT  —  Show assets licensed under the MIT license (use SPDX identif
 updated_at > 2020-01-01  —  Show assets updated after January 1 2020
 EOF);
               @endphp
-              <form method="GET" action="{{ route('asset.index') }}" class="lg:ml-2"
+              <form method="GET" action="{{ route('asset.index') }}" class="lg:ml-2 relative"
                 aria-label="{{ $searchTooltip }}"
                 data-balloon-pos="down"
                 data-balloon-break
@@ -77,7 +77,7 @@ EOF);
                   value="{{ Request::get('filter') }}"
                   class="form-input-text shadow-none bg-gray-200 dark:bg-gray-700 lg:w-64"
                 >
-                <span class="fa fa-search absolute right-0 mt-2 mr-3 pointer-events-none text-gray-500"></span>
+                <span class="fa fa-search absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-gray-500"></span>
               </form>
             </div>
 


### PR DESCRIPTION
- Tweaks the styles of the magnifying glass to center it in the search bar
- Reduces opacity on balloon so it is easier to read

<img width="269" alt="Screen Shot 2022-07-22 at 1 43 00 PM" src="https://user-images.githubusercontent.com/9118169/180494962-657a34f3-2e42-4dfe-b588-cd3dacd65607.png">

<img width="595" alt="Screen Shot 2022-07-22 at 1 46 44 PM" src="https://user-images.githubusercontent.com/9118169/180496639-f1a4777a-6ed0-4334-9be0-c845ee5bc4a6.png">
<img width="570" alt="Screen Shot 2022-07-22 at 1 53 13 PM" src="https://user-images.githubusercontent.com/9118169/180496642-1cf5dfc5-d30f-4b3a-94e9-e65ecd5f02bc.png">

